### PR TITLE
fix: nommage des champs Conditions d'accès et Présentation résumée

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -253,7 +253,7 @@
             }
         },
         {
-            "name": "presentation_resume",
+            "name": "presentation_resumee",
             "title": "Présentation résumé",
             "description": "Ce champ contient une courte description du lieu (500 caractères maximum).",
             "example": "Notre association propose des formations aux outils numériques à destination des personnes âgées.",
@@ -327,7 +327,7 @@
             }
         },
         {
-            "name": "conditions_acces",
+            "name": "conditions_access",
             "title": "Conditions d'accès",
             "description": "Ce champ indique les conditions financières d'accès au lieu. Sélectionner une ou plusieurs valeurs séparées par un point-virgule sans espace parmi la liste suivante : Gratuit : Je peux accéder gratuitement au lieu et à ses services ; Gratuit sous condition : La gratuité est conditionnée à des critères (situation familiale, convention avec un organisme social...) ; Payant : L'accès au lieu et\/ou à ses services est payant ; Accepte le Pass numérique : Il est possible d'utiliser un Pass numérique pour accéder au lieu",
             "example": "Gratuit sous condition : La gratuité est conditionnée à des critères (situation familiale, convention avec un organisme social...);Payant : L'accès au lieu et/ou à ses services est payant;Accepte le Pass numérique : Il est possible d'utiliser un Pass numérique pour accéder au lieu",


### PR DESCRIPTION
Le nommage des champs `Conditions d'accès` et `Présentation résumée` n'est pas cohérent entre ce qui est spécifié dans la documentation et le schéma :
- Dans la documentation l'identifiant du champ `Présentation résumée` est `presentation_resumee` alors qu'il s'agit de `presentation_resume` dans le schéma
- Dans la documentation l'identifiant du champ `Conditions d'accès` est `conditions_access` alors qu'il s'agit de `conditions_acces` dans le schéma

Je propose ici d'aligner le schéma sur la documentation, mais l'inverse est également possible.