### PR TITLE
fix: Manque des caractères d'échappement pour le pattern de publics_accueillis

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -323,7 +323,7 @@
             "type": "string",
             "constraints": {
                 "required": false,
-                "pattern": "(?:(?:^|;)(Seniors \\(\\+ 65 ans\\)|Familles\/enfants|Adultes|Jeunes (16-26 ans)|Public langues étrangères|Déficience visuelle|Surdité|Handicaps psychiques : troubles psychiatriques donnant lieu à des atteintes comportementales|Handicaps mentaux : déficiences limitant les activités d'une personne|Uniquement femmes|Personnes en situation d'illettrisme))+$"
+                "pattern": "(?:(?:^|;)(Seniors \\(\\+ 65 ans\\)|Familles\/enfants|Adultes|Jeunes \\(16-26 ans\\)|Public langues étrangères|Déficience visuelle|Surdité|Handicaps psychiques : troubles psychiatriques donnant lieu à des atteintes comportementales|Handicaps mentaux : déficiences limitant les activités d'une personne|Uniquement femmes|Personnes en situation d'illettrisme))+$"
             }
         },
         {


### PR DESCRIPTION
La valeur `Jeunes (16-26 ans)` doit avoir des caractères d'échappement pour les parenthèses sinon, le pattern va chercher à sélectionner le groupe `16-26 ans` au lieu de rechercher la valeur `Jeunes (16-26 ans)` dans une chaîne.

- Reproduction du problème : https://regex101.com/r/WZdfic/1
- Avec la correction : https://regex101.com/r/JwRTgE/1