### PR TITLE
Rend le code INSEE obligatoire

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -147,7 +147,7 @@
             "example": "51454",
             "type": "string",
             "constraints": {
-                "required": false,
+                "required": true,
                 "pattern":"^([013-9]\\d|2[AB1-9])\\d{3}$"
             }
         },


### PR DESCRIPTION
Le code INSEE de la commune dans laquelle se trouve le lieu est ce qui permet de faire des jointures avec énormément de données administratives. Pensez-vous qu'il serait possible de le rendre obligatoire dans les futures versions du schéma ?

Il nous serait particulièrement utile pour la production de données de suivi dans le contexte de "France Numérique Ensemble".